### PR TITLE
Fix (lighten) quoted text in jira comments

### DIFF
--- a/dark-liferay-issues.user.css
+++ b/dark-liferay-issues.user.css
@@ -385,4 +385,7 @@
     left: 0;
     width: 2px;
   }
+  .action-body blockquote {
+    color: #ccc;
+  }
 }


### PR DESCRIPTION
I couldn't read the text in a Jira comment (`.action-body blockquote`). I've added the color for it at the end of the file.